### PR TITLE
Change argument order for add/remove match exist check

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -483,7 +483,7 @@ class MessageBus extends EventEmitter {
   }
 
   _addMatch (match) {
-    if (Object.prototype.hasOwnProperty.call(match, this._matchRules)) {
+    if (Object.prototype.hasOwnProperty.call(this._matchRules, match)) {
       this._matchRules[match] += 1;
       return Promise.resolve();
     }
@@ -507,7 +507,7 @@ class MessageBus extends EventEmitter {
       return Promise.resolve();
     }
 
-    if (Object.prototype.hasOwnProperty.call(match, this._matchRules)) {
+    if (Object.prototype.hasOwnProperty.call(this._matchRules, match)) {
       this._matchRules[match] -= 1;
       if (this._matchRules[match] > 0) {
         return Promise.resolve();


### PR DESCRIPTION
Attempts to correct logic to intended behaviour. That is, check existing property `match` on `this._matchRules` instead of `this._matchRules` on `match`.