### PR TITLE
Fix module name causing incorrect types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,5 @@
 
-declare module 'dbus-next' {
+declare module '@jellybrick/dbus-next' {
     import { EventEmitter } from "events";
 
     export type ObjectPath = string;


### PR DESCRIPTION
After you forked, you should have updated the module name from `dbus-next` to `@jellybrick/dbus-next` so the types would show correctly with the new import name.