### PR TITLE
Drop x11 dependency

### DIFF
--- a/lib/address-x11.js
+++ b/lib/address-x11.js
@@ -1,44 +1,4 @@
 const fs = require('fs');
-const os = require('os');
-
-function getDbusAddressFromWindowSelection (callback) {
-  // read dbus adress from window selection
-  // TODO: implement this somewhere
-  const x11 = require('x11');
-  if (x11 === null) {
-    throw new Error('cannot get session bus address from window selection: dbus-next was installed without x11 support');
-  }
-
-  // read machine uuid
-  fs.readFile('/var/lib/dbus/machine-id', 'ascii', function (err, uuid) {
-    if (err) return callback(err);
-    const hostname = os.hostname().split('-')[0];
-    x11.createClient(function (err, display) {
-      if (err) return callback(err);
-      const X = display.client;
-      const selectionName = `_DBUS_SESSION_BUS_SELECTION_${
-        hostname
-      }_${uuid.trim()}`;
-      X.InternAtom(false, selectionName, function (err, id) {
-        if (err) return callback(err);
-        X.GetSelectionOwner(id, function (err, win) {
-          if (err) return callback(err);
-          X.InternAtom(false, '_DBUS_SESSION_BUS_ADDRESS', function (
-            err,
-            propId
-          ) {
-            if (err) return callback(err);
-            win = display.screen[0].root;
-            X.GetProperty(0, win, propId, 0, 0, 10000000, function (err, val) {
-              if (err) return callback(err);
-              callback(null, val.data.toString());
-            });
-          });
-        });
-      });
-    });
-  });
-}
 
 function getDbusAddressFromFs () {
   const home = process.env.HOME;
@@ -77,5 +37,4 @@ function getDbusAddressFromFs () {
 
 module.exports = {
   getDbusAddressFromFs: getDbusAddressFromFs,
-  getDbusAddressFromWindowSelection: getDbusAddressFromWindowSelection
 };


### PR DESCRIPTION
It seems, that the function that includes x11 as dependency is actually not really used anywhere in the `mpris-service`, I haven't dug through to find if anything in any other package depends on that function. However there seems to be many ways to avoid the `x11` dependency.

Closes: #6